### PR TITLE
refactor: Update beliefs terminology from "Principios de Fe" to "Creencias fundamentales"

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
         <div class="col-lg-3 col-md-6 mb-4 mb-lg-0">
           <h5>Enlaces Rápidos</h5>
           <ul class="footer-links">
-            <li><a href="{{ site.baseurl }}/principles">Principios de Fe</a></li>
+            <li><a href="{{ site.baseurl }}/principles">Creencias fundamentales</a></li>
             <li><a href="{{ site.baseurl }}/ministry">Ministerio</a></li>
             <li><a href="{{ site.baseurl }}/resources">Recursos</a></li>
             <li><a href="{{ site.baseurl }}/about.html">Acerca de</a></li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
           </a>
           <ul class="dropdown-menu">
             <li><a class="dropdown-item" href="{{ site.baseurl }}/about.html">Quienes Somos</a></li>
-            <li><a class="dropdown-item" href="{{ site.baseurl }}/principles">Principios de Fe</a></li>
+            <li><a class="dropdown-item" href="{{ site.baseurl }}/principles">Creencias fundamentales</a></li>
             <li><a class="dropdown-item" href="{{ site.baseurl }}/ministry">Ministerio</a></li>
             <li><a class="dropdown-item" href="{{ site.baseurl }}/departments">Departamentos</a></li>
           </ul>

--- a/_layouts/home_style.html
+++ b/_layouts/home_style.html
@@ -83,7 +83,7 @@ layout: base
                         <i class="fa-solid fa-book-bible"></i>
                     </div>
                     <h3>Nuestras Creencias</h3>
-                    <p>Conoce los 25 principios de fe que guían nuestra doctrina y práctica cristiana.</p>
+                    <p>Conoce las 25 creencias fundamentales que guían nuestra doctrina y práctica cristiana.</p>
                     <a href="{{ site.baseurl }}/principles" class="btn">Ver Principios</a>
                 </div>
             </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1569,30 +1569,73 @@ Custom
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 24px;
+  grid-auto-rows: 1fr;
 }
 
 .principle-card {
-  display: block;
-  border-radius: 12px;
-  overflow: hidden;
-  transition: all 0.3s ease;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  min-height: 140px;
+  padding: 28px 28px 28px 36px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #0b2b66 0%, #0a245e 50%, #0a2f73 100%);
+  color: #ffffff;
+  text-decoration: none;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  box-shadow: 0 10px 22px rgba(7, 18, 44, 0.18);
 }
 
 .principle-card:hover {
   transform: translateY(-6px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 18px 36px rgba(7, 18, 44, 0.28);
 }
 
-.principle-card img {
-  width: 100%;
-  height: auto;
-  display: block;
-  transition: transform 0.4s ease;
+.principle-card::before {
+  content: "";
+  position: absolute;
+  left: 16px;
+  top: 18px;
+  bottom: 18px;
+  width: 4px;
+  border-radius: 999px;
+  background: #facc15;
+  opacity: 0.8;
+  transition: opacity 0.25s ease, box-shadow 0.25s ease;
 }
 
-.principle-card:hover img {
-  transform: scale(1.03);
+.principle-card:hover::before {
+  opacity: 1;
+  box-shadow: 0 0 12px rgba(250, 204, 21, 0.5);
+}
+
+.principle-card-title {
+  position: relative;
+  display: inline-block;
+  font-family: 'Poppins', sans-serif;
+  font-size: 1.2rem;
+  font-weight: 700;
+  letter-spacing: 0.2px;
+  line-height: 1.35;
+  color: #ffffff;
+  transition: color 0.25s ease, text-shadow 0.25s ease;
+}
+
+.principle-card-title:hover {
+  color: #facc15;
+  text-shadow: 0 0 8px rgba(250, 204, 21, 0.35);
+}
+
+.principle-card:hover .principle-card-title {
+  color: #facc15;
+  text-shadow: 0 0 8px rgba(250, 204, 21, 0.35);
+}
+
+.principle-card:focus,
+.principle-card:focus-visible {
+  outline: 3px solid rgba(250, 204, 21, 0.55);
+  outline-offset: 3px;
 }
 
 @media (max-width: 991px) {

--- a/pages/about.html
+++ b/pages/about.html
@@ -141,12 +141,12 @@ sidebar_content: |
 <section id="creencias" class="about-section">
   <h2 class="about-section-header">Nuestras Creencias</h2>
   <p class="paragraph-text">
-    Nuestra fe se fundamenta en 25 Principios de Fe que abarcan las doctrinas esenciales de las Sagradas Escrituras. Estos principios guían nuestra comprensión de Dios, la salvación, la iglesia, y la esperanza del pronto regreso de Cristo.
+    Nuestra fe se fundamenta en 25 Creencias fundamentales que abarcan las doctrinas esenciales de las Sagradas Escrituras. Estas creencias guían nuestra comprensión de Dios, la salvación, la iglesia, y la esperanza del pronto regreso de Cristo.
   </p>
   <p class="paragraph-text">
     Creemos en la Biblia como la Palabra inspirada de Dios, en la observancia del sábado como día de reposo, en el pronto regreso de Jesucristo, y en un estilo de vida que refleje los principios del reino de Dios.
   </p>
   <a href="{{ site.baseurl }}/principles" class="btn-custom-pdf" style="margin-top: 20px;">
-    <i class="fa fa-arrow-right"></i> Ver Nuestros 25 Principios de Fe
+    <i class="fa fa-arrow-right"></i> Ver nuestras 25 creencias fundamentales
   </a>
 </section>

--- a/pages/sections/principles.html
+++ b/pages/sections/principles.html
@@ -1,6 +1,6 @@
 ---
 layout: default_style
-title: Principios de Fe
+title: Creencias fundamentales
 permalink: /principles
 description: |
     Explora los 25 fundamentos de nuestra creencia, basados en la Biblia y
@@ -34,9 +34,7 @@ description: |
         <div class="principles-grid">
             {% for principle in site.data.principles %}
             <a href="{{ site.baseurl }}{{ principle.link }}" class="principle-card">
-                <img src="{{ site.baseurl }}/assets/img/principles/principle_{{ principle.id }}.png"
-                     alt="{{ principle.title }}"
-                     loading="lazy">
+                <span class="principle-card-title">{{ principle.title }}</span>
             </a>
             {% endfor %}
         </div>


### PR DESCRIPTION
## Overview
This PR updates the terminology used throughout the website to reflect more accurate and consistent language for the church's doctrinal statements, changing from "Principios de Fe" (Principles of Faith) to "Creencias fundamentales" (Fundamental Beliefs).

## Changes
-  Updated terminology across all navigation menus and links
-  Enhanced principle card design with improved hover effects and visual presentation
-  Modified card display to show titles directly instead of images
-  Improved layout and spacing for better readability

## Files Modified
- `_includes/footer.html` - Updated footer link text
- `_includes/header.html` - Updated navigation dropdown text
- `_layouts/home_style.html` - Updated home section description
- `pages/about.html` - Updated beliefs section text and button label
- `pages/sections/principles.html` - Updated page title and card display
- `assets/css/style.css` - Enhanced principle card styles with new hover effects